### PR TITLE
Track page views by slug using StatsServer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           mix local.rebar --force && mix local.hex --force
           mix deps.get
 
+      - name: Ensure no compile warnings
+        run: mix compile --warnings-as-errors
+
       - name: Check if the code is formatted
         run: mix format --check-formatted
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@
 import Config
 
 config :shortener,
-  ecto_repos: [Shortener.Repo]
+  ecto_repos: [Shortener.Repo],
+  stats_server_persist_interval: :timer.seconds(30)
 
 # Configures the endpoint
 config :shortener, ShortenerWeb.Endpoint,

--- a/lib/shortener/application.ex
+++ b/lib/shortener/application.ex
@@ -7,30 +7,24 @@ defmodule Shortener.Application do
 
   @impl true
   def start(_type, _args) do
-    children = [
-      # Start the Ecto repository
-      Shortener.Repo,
-      # Start the Telemetry supervisor
-      ShortenerWeb.Telemetry,
-      # Start the PubSub system
-      {Phoenix.PubSub, name: Shortener.PubSub},
-      # Start the Endpoint (http/https)
-      ShortenerWeb.Endpoint
-      # Start a worker by calling: Shortener.Worker.start_link(arg)
-      # {Shortener.Worker, arg}
-    ]
+    children =
+      [
+        Shortener.Repo,
+        ShortenerWeb.Telemetry,
+        {Phoenix.PubSub, name: Shortener.PubSub},
+        {Task.Supervisor, name: Shortener.TaskSupervisor}
+      ] ++ servers(env: Mix.env()) ++ [ShortenerWeb.Endpoint]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Shortener.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
   @impl true
   def config_change(changed, _new, removed) do
     ShortenerWeb.Endpoint.config_change(changed, removed)
     :ok
   end
+
+  defp servers(env: :test), do: []
+  defp servers(env: _), do: [Shortener.ShortenedURLs.StatsServer]
 end

--- a/lib/shortener/shortened_urls.ex
+++ b/lib/shortener/shortened_urls.ex
@@ -5,13 +5,22 @@ defmodule Shortener.ShortenedURLs do
 
   import Ecto.Query
   alias Shortener.Repo
-  alias Shortener.ShortenedURLs.ShortenedURL
+  alias Shortener.ShortenedURLs.{ShortenedURL, StatsServer}
 
+  @db_pool_size Application.compile_env!(:shortener, Repo)[:pool_size]
+
+  @doc """
+  Creates a brand new Ecto.Changeset for ShortenedURL.
+  """
   @spec new :: Ecto.Changeset.t()
   def new do
     ShortenedURL.changeset(%ShortenedURL{})
   end
 
+  @doc """
+  Creates a ShortenedURL for the given url. Validations are performed using
+  Ecto and a Changeset is returned in case of errors.
+  """
   @spec create(ShortenedURL.url()) :: {:ok, ShortenedURL.t()} | {:error, Ecto.Changeset.t()}
   def create(url) do
     %ShortenedURL{}
@@ -19,6 +28,9 @@ defmodule Shortener.ShortenedURLs do
     |> Repo.insert()
   end
 
+  @doc """
+  Finds a ShortenedURL for the given slug.
+  """
   @spec find(ShortenedURL.slug()) :: {:ok, ShortenedURL.t()} | {:error, :not_found}
   def find(slug) do
     query = from su in ShortenedURL, where: su.slug == ^slug
@@ -27,5 +39,32 @@ defmodule Shortener.ShortenedURLs do
       nil -> {:error, :not_found}
       shortened_url -> {:ok, shortened_url}
     end
+  end
+
+  @doc """
+  Calls the StatsServer to track a page view for the given slug.
+  """
+  @spec track_page_view(ShortenedURL.slug()) :: :ok
+  def track_page_view(slug) do
+    StatsServer.track_page_view(slug)
+  end
+
+  @doc """
+  Persists pages views by slug ensuring performance by grouping slugs with
+  same pages views and running Repo update queries asynchronously.
+  """
+  @spec persist_page_views(map) :: :ok
+  def persist_page_views(page_views_by_slug) do
+    page_views_by_slug
+    |> Enum.group_by(fn {_slug, page_view} -> page_view end, fn {slug, _page_view} -> slug end)
+    |> Task.async_stream(&update_page_views(&1), max_concurrency: div(@db_pool_size, 2))
+    |> Stream.run()
+  end
+
+  defp update_page_views({page_views, slugs}) do
+    Repo.update_all(
+      from(su in ShortenedURL, where: su.slug in ^slugs),
+      inc: [page_views: page_views]
+    )
   end
 end

--- a/lib/shortener/shortened_urls/shortened_url.ex
+++ b/lib/shortener/shortened_urls/shortened_url.ex
@@ -20,13 +20,14 @@ defmodule Shortener.ShortenedURLs.ShortenedURL do
   schema "shortened_urls" do
     field :slug, :string, autogenerate: {SlugGenerator, :generate, [@slug_size]}
     field :url, :string
+    field :page_views, :integer
 
     timestamps()
   end
 
   def changeset(shortened_url, attrs \\ %{}) do
     shortened_url
-    |> cast(attrs, [:url])
+    |> cast(attrs, [:url, :page_views])
     |> validate_required([:url])
     |> validate_url()
     |> unique_constraint(:slug)

--- a/lib/shortener/shortened_urls/stats_server.ex
+++ b/lib/shortener/shortened_urls/stats_server.ex
@@ -1,0 +1,75 @@
+defmodule Shortener.ShortenedURLs.StatsServer do
+  use GenServer
+  alias Shortener.ShortenedURLs
+
+  @moduledoc """
+  StatsServer keeps track of Shortened URL page views. Everytime a Shortened URL
+  is requested, we increment the page views counter in the StatsServer state. Page
+  views are then persisted in the database every configured interval (`:stats_server_persist_interval`).
+
+  We trap exits to make sure page views are persisted in the event StatsServer goes
+  down or the application is shutting down.
+  """
+
+  @name __MODULE__
+  @initial_value 1
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: @name)
+  end
+
+  @impl true
+  def init(state) do
+    Process.flag(:trap_exit, true)
+    schedule_work()
+    {:ok, state}
+  end
+
+  def track_page_view(slug) do
+    GenServer.cast(@name, {:track_page_view, slug})
+  end
+
+  @impl true
+  def handle_cast({:track_page_view, slug}, state) do
+    new_state = Map.update(state, slug, @initial_value, &(&1 + 1))
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_info(:persist_page_views, state) do
+    Task.Supervisor.async_nolink(Shortener.TaskSupervisor, fn ->
+      ShortenedURLs.persist_page_views(state)
+      :persisted
+    end)
+
+    new_state = %{}
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_info({_ref, :persisted}, state) do
+    schedule_work()
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, _, _, :normal}, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, _, _, _error}, state) do
+    schedule_work()
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_, state) do
+    ShortenedURLs.persist_page_views(state)
+  end
+
+  defp schedule_work do
+    update_interval = Application.get_env(:shortener, :stats_server_persist_interval)
+    Process.send_after(self(), :persist_page_views, update_interval)
+  end
+end

--- a/lib/shortener_web/controllers/url_shortener_controller.ex
+++ b/lib/shortener_web/controllers/url_shortener_controller.ex
@@ -22,6 +22,7 @@ defmodule ShortenerWeb.URLShortenerController do
   def show(conn, %{"slug" => slug}) do
     case ShortenedURLs.find(slug) do
       {:ok, shortened_url} ->
+        ShortenedURLs.track_page_view(shortened_url.slug)
         redirect(conn, external: shortened_url.url)
 
       {:error, :not_found} ->

--- a/priv/repo/migrations/20230207124906_add_page_views_to_shortened_url.exs
+++ b/priv/repo/migrations/20230207124906_add_page_views_to_shortened_url.exs
@@ -1,0 +1,9 @@
+defmodule Shortener.Repo.Migrations.AddPageViewsToShortenedURL do
+  use Ecto.Migration
+
+  def change do
+    alter table(:shortened_urls) do
+      add :page_views, :integer, null: false, default: 0
+    end
+  end
+end

--- a/test/shortener/shortened_urls/stats_server_test.exs
+++ b/test/shortener/shortened_urls/stats_server_test.exs
@@ -1,0 +1,111 @@
+defmodule Shortener.ShortenedURLs.StatsServerTest do
+  use Shortener.DataCase
+  alias Shortener.ShortenedURLs.{SlugGenerator, ShortenedURL, StatsServer}
+
+  describe "init" do
+    test "initializes the server state" do
+      start_supervised!(StatsServer)
+      assert %{} == :sys.get_state(StatsServer)
+    end
+  end
+
+  describe "track_page_view/1" do
+    test "tracks page view for a single slug" do
+      start_supervised!(StatsServer)
+
+      StatsServer.track_page_view("TESTSLUG")
+      assert %{"TESTSLUG" => 1} == :sys.get_state(StatsServer)
+
+      StatsServer.track_page_view("TESTSLUG")
+      assert %{"TESTSLUG" => 2} == :sys.get_state(StatsServer)
+    end
+
+    test "tracks page views for multiple slugs" do
+      start_supervised!(StatsServer)
+
+      StatsServer.track_page_view("TESTSLUG")
+      StatsServer.track_page_view("OTHERSLUG")
+      assert %{"TESTSLUG" => 1, "OTHERSLUG" => 1} == :sys.get_state(StatsServer)
+
+      StatsServer.track_page_view("OTHERSLUG")
+      assert %{"TESTSLUG" => 1, "OTHERSLUG" => 2} == :sys.get_state(StatsServer)
+    end
+  end
+
+  describe "handle_info - :persist_page_views" do
+    test "persists page views for each slug" do
+      Mox.expect(SlugGenerator.Mock, :generate, fn _ -> "TESTSLUG" end)
+      Mox.expect(SlugGenerator.Mock, :generate, fn _ -> "OTHERSLUG" end)
+
+      shortened_url = fixture(:shortened_url, %{page_views: 0})
+      other_shortened_url = fixture(:shortened_url, %{page_views: 0})
+      start_supervised!(StatsServer)
+
+      StatsServer.track_page_view("TESTSLUG")
+      StatsServer.track_page_view("OTHERSLUG")
+      StatsServer.track_page_view("OTHERSLUG")
+
+      send(StatsServer, :persist_page_views)
+      wait_for_message_process!()
+
+      shortened_url = Repo.reload(shortened_url)
+      assert %ShortenedURL{page_views: 1} = shortened_url
+
+      other_shortened_url = Repo.reload(other_shortened_url)
+      assert %ShortenedURL{page_views: 2} = other_shortened_url
+    end
+
+    test "resets state" do
+      start_supervised!(StatsServer)
+
+      send(StatsServer, :persist_page_views)
+      wait_for_message_process!()
+
+      assert %{} == :sys.get_state(StatsServer)
+    end
+
+    test "schedules next update" do
+      # speed up tests by temporarily setting update interval to 50
+      switch_update_interval(50)
+
+      stats_server_pid = start_supervised!(StatsServer)
+      :erlang.trace(stats_server_pid, true, [:receive])
+
+      send(StatsServer, :persist_page_views)
+      wait_for_message_process!()
+
+      assert_received {:trace, ^stats_server_pid, :receive, :persist_page_views}
+    end
+  end
+
+  describe "terminate/2" do
+    @tag slug_stub: "TESTSLUG"
+    test "persists page views before terminating" do
+      shortened_url = fixture(:shortened_url, %{page_views: 0})
+      start_supervised!(StatsServer)
+
+      StatsServer.track_page_view("TESTSLUG")
+
+      stop_supervised!(StatsServer)
+
+      shortened_url = Repo.reload(shortened_url)
+      assert %ShortenedURL{page_views: 1} = shortened_url
+    end
+  end
+
+  # Ensure async processes that update the db finish before proceeding
+  defp wait_for_message_process! do
+    stats_server_pid = Process.whereis(StatsServer)
+    :erlang.trace(stats_server_pid, true, [:receive])
+    assert_receive {:trace, ^stats_server_pid, :receive, {_ref, :persisted}}, 500
+  end
+
+  defp switch_update_interval(new_interval) do
+    current_update_interval = Application.get_env(:shortener, :stats_server_persist_interval)
+    Application.put_env(:shortener, :stats_server_persist_interval, new_interval)
+
+    on_exit(fn ->
+      Application.put_env(:shortener, :stats_server_persist_interval, current_update_interval)
+    end)
+  end
+end


### PR DESCRIPTION
## Description

StatsServer is a GenServer that tracks and persists page views for Shortened URL slugs.

* The server state holds page views for all slugs that have been viewed.
* Every 5 seconds we persist the page views in the database and reset the state.
* The server gracefully handles termination, ensuring page views are persisted when exiting.